### PR TITLE
Add optional computer opponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Modular two-player territory capture game on a hex grid built with Phaser 3.
 
 `src/GameManager.js` – Core game rules, turn logic, move validation, piece placement and conversion, scoring, game-over detection.
 
+`src/AI.js` – Simple move evaluation for a basic computer opponent.
+
 `src/UIManager.js` – Score + turn text and game-over overlay.
 
 `src/GameScene.js` – Wires subsystems inside a Phaser Scene.
@@ -29,6 +31,8 @@ python3 -m http.server 8000
 Visit: http://localhost:8000
 
 ## Gameplay
+When loading the page you'll be prompted to face another human or a basic computer opponent. Selecting the computer enables an AI to control the Democrats (player two).
+
 Select one of your pieces (Republicans red / Democrats blue). Valid duplicate (adjacent) and jump (further) destinations are computed (visual highlight placeholders ready—enhance further as needed). Move duplicates or jumps; adjacent opponent pieces convert. Board / move exhaustion ends the game; higher piece count wins.
 
 ## Next Ideas

--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 import { GameScene } from './src/GameScene.js';
 
+// Ask the user if they want to face the computer before starting the game
+const vsAI = window.confirm('Play against computer?');
+
 const config = {
   type: Phaser.AUTO,
   width: 900,
   height: 800,
-  backgroundColor: '#f2f2f2',
-  scene: [GameScene]
+  backgroundColor: '#f2f2f2'
 };
 
-new Phaser.Game(config);
+const game = new Phaser.Game(config);
+game.scene.add('GameScene', GameScene);
+game.scene.start('GameScene', { vsAI });

--- a/src/AI.js
+++ b/src/AI.js
@@ -1,0 +1,59 @@
+export function performAIMove(gameManager) {
+  const moves = [];
+  const board = gameManager.board;
+  board.forEachHex(hex => {
+    const piece = hex.data.values.piece;
+    if (piece && piece.data.values.player === gameManager.currentPlayer) {
+      const { q, r } = piece.data.values;
+      getValidMovesForPiece(board, q, r).forEach(m => moves.push({ ...m, piece }));
+    }
+  });
+  if (moves.length === 0) { gameManager.endTurn(); return; }
+  let best = moves[0];
+  let bestScore = potentialGain(board, best.q, best.r, gameManager.currentPlayer);
+  moves.forEach(m => {
+    const score = potentialGain(board, m.q, m.r, gameManager.currentPlayer);
+    if (score > bestScore) { best = m; bestScore = score; }
+  });
+  gameManager.selectedPiece = best.piece;
+  gameManager.executeMove(best);
+}
+
+function getValidMovesForPiece(board, q, r) {
+  const moves = [];
+  for (let dq = -2; dq <= 2; dq++) {
+    for (let dr = -2; dr <= 2; dr++) {
+      const nq = q + dq;
+      const nr = r + dr;
+      if (dq === 0 && dr === 0) continue;
+      const dist = axialDistance(q, r, nq, nr);
+      if (dist > 2) continue;
+      const hex = board.getHex(nq, nr);
+      if (!hex || hex.data.values.piece) continue;
+      const type = (dist === 1) ? 'duplicate' : (dist === 2 ? 'jump' : null);
+      if (type) moves.push({ q: nq, r: nr, type });
+    }
+  }
+  return moves;
+}
+
+function potentialGain(board, q, r, player) {
+  let gain = 0;
+  directionsDuplicate().forEach(([dq, dr]) => {
+    const hex = board.getHex(q + dq, r + dr);
+    if (hex && hex.data.values.piece && hex.data.values.piece.data.values.player !== player) {
+      gain++;
+    }
+  });
+  return gain;
+}
+
+function directionsDuplicate() {
+  return [[1,0],[-1,0],[0,1],[0,-1],[1,-1],[-1,1]];
+}
+
+function axialDistance(q1, r1, q2, r2) {
+  const x1 = q1, z1 = r1, y1 = -x1 - z1;
+  const x2 = q2, z2 = r2, y2 = -x2 - z2;
+  return Math.max(Math.abs(x1 - x2), Math.abs(y1 - y2), Math.abs(z1 - z2));
+}

--- a/src/GameScene.js
+++ b/src/GameScene.js
@@ -5,6 +5,7 @@ import { UIManager } from './UIManager.js';
 
 export class GameScene extends Phaser.Scene {
   constructor() { super('GameScene'); }
+  init(data) { this.vsAI = data?.vsAI; }
   preload() {}
 
   create() {
@@ -12,7 +13,7 @@ export class GameScene extends Phaser.Scene {
     this.board.generate();
 
     this.ui = new UIManager(this);
-    this.gameManager = new GameManager(this.board, this.ui, this, {});
+    this.gameManager = new GameManager(this.board, this.ui, this, { vsAI: this.vsAI });
 
     // Register hex clicks
     this.board.hexMap.forEach(hex => {


### PR DESCRIPTION
## Summary
- Prompt users at startup to choose a human or computer opponent
- Pass AI setting into the scene and game manager
- Implement simple move-evaluating AI for player two and update README
- Extract computer move logic into dedicated `AI.js` module

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68961de5625c832db5d0c9f2c9b8941a