### PR TITLE
refactor: modularize game modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ PORT ?= 8000
 MSG ?= autocommit: update
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo master)
 
-.PHONY: help serve open push gp status
+.PHONY: help serve open push gp status tests
 
 # Collect any extra words after 'push' or 'gp' as commit message override.
-EXTRA_MSG_WORDS := $(filter-out push gp,$(MAKECMDGOALS))
+EXTRA_MSG_WORDS := $(filter-out push gp tests,$(MAKECMDGOALS))
 EFFECTIVE_MSG := $(strip $(if $(EXTRA_MSG_WORDS),$(EXTRA_MSG_WORDS),$(MSG)))
 
 # Declare extra words as phony no-op targets so make doesn't error.
@@ -22,8 +22,8 @@ help:
 	@echo "  make open         # Open the game in default browser (macOS 'open')"
 	@echo "  make push MSG=...           # git add ., commit with MSG and push to BRANCH (default MSG)"
 	@echo "  make push some words here   # trailing words become commit message (quotes optional)"
-	@echo "  make gp MSG=...   # Alias for push"
 	@echo "  make status       # Show git status concise"
+	@echo "  make tests        # Run unit tests"
 	@echo "Variables: PORT, MSG, BRANCH"
 
 serve:
@@ -49,3 +49,6 @@ gp: push
 
 status:
 	@git status -sb
+
+tests:
+	npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "capitol-conquest",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/GameManager.js
+++ b/src/GameManager.js
@@ -505,7 +505,7 @@ export class GameManager {
     this.currentPlayer = (this.currentPlayer === 1) ? 2 : 1;
     this.ui.updateTurn(this.players[this.currentPlayer].name);
     this.ui.flashTurn(this.players[this.currentPlayer].name);
-  if (this.scene.mode === 'single' && this.players[this.currentPlayer].isAI && this.scene.aiPlayer) {
+    if (this.players[this.currentPlayer].isAI && this.scene.aiPlayer) {
       // Let UI update before AI moves
       this.scene.time.delayedCall(350, () => this.aiTurn(), [], this);
     }

--- a/src/MenuScene.js
+++ b/src/MenuScene.js
@@ -39,13 +39,14 @@ export class MenuScene extends Phaser.Scene {
     // Add resize listener for mobile viewport changes
     this.scale.on('resize', this.handleResize, this);
     
-    const options = [
-      { label:'Single Player (vs AI)', mode:'single' },
-      { label:'Two Player Local', mode:'two' },
-      { label:'Global Statistics', mode:'stats' },
-      { label:'Help & Rules', mode:'help' },
-      { label:'Reset Local Scores', mode:'reset' }
-    ];
+      const options = [
+        { label:'Single Player (vs AI)', mode:'single' },
+        { label:'Two Player Local', mode:'two' },
+        { label:'Online Multiplayer', mode:'online' },
+        { label:'Global Statistics', mode:'stats' },
+        { label:'Help & Rules', mode:'help' },
+        { label:'Reset Local Scores', mode:'reset' }
+      ];
     this.items = [];
     options.forEach((o,i)=>{
       const fontSize = layout.isMobile ? Config.FONT_SIZES.SMALL : Config.FONT_SIZES.MEDIUM;
@@ -106,7 +107,7 @@ export class MenuScene extends Phaser.Scene {
   }
   _activate(){ 
     if (this.sel === -1) return; // Do nothing if no item selected
-    const map = ['single','two','stats','help','reset']; 
+      const map = ['single','two','online','stats','help','reset'];
     this._select({ mode: map[this.sel] }); 
   }
   _select(o){

--- a/src/modes/BaseMode.js
+++ b/src/modes/BaseMode.js
@@ -1,0 +1,13 @@
+export class BaseMode {
+  constructor(scene, options = {}) {
+    this.scene = scene;
+    this.options = options;
+  }
+  getGameManagerOptions() {
+    // By default return options unchanged
+    return this.options;
+  }
+  setup() {
+    // Mode specific setup after GameManager creation
+  }
+}

--- a/src/modes/LocalMultiplayerMode.js
+++ b/src/modes/LocalMultiplayerMode.js
@@ -1,0 +1,5 @@
+import { BaseMode } from './BaseMode.js';
+
+export class LocalMultiplayerMode extends BaseMode {
+  // No additional setup required; purely uses core GameScene
+}

--- a/src/modes/OnlineMultiplayerMode.js
+++ b/src/modes/OnlineMultiplayerMode.js
@@ -1,0 +1,12 @@
+import { BaseMode } from './BaseMode.js';
+import { NetworkClient } from '../online/NetworkClient.js';
+import { ChatUI } from '../online/ChatUI.js';
+
+export class OnlineMultiplayerMode extends BaseMode {
+  setup() {
+    // Initialize networking and chat UI
+    this.network = new NetworkClient(this.scene);
+    this.network.connect();
+    this.chat = new ChatUI(this.scene);
+  }
+}

--- a/src/modes/SinglePlayerMode.js
+++ b/src/modes/SinglePlayerMode.js
@@ -1,0 +1,36 @@
+import { BaseMode } from './BaseMode.js';
+import { AI } from '../AI.js';
+import { Config } from '../config.js';
+
+export class SinglePlayerMode extends BaseMode {
+  getGameManagerOptions() {
+    const base = { ...this.options };
+    if (base.playerChoice) {
+      base.players = {
+        1: {
+          id: 1,
+          name: 'Republicans',
+          color: base.playerChoice.playerId === 1 ? base.playerChoice.playerColor : base.playerChoice.aiColor,
+          score: 0,
+          isAI: false
+        },
+        2: {
+          id: 2,
+          name: 'Democrats',
+          color: base.playerChoice.playerId === 2 ? base.playerChoice.playerColor : base.playerChoice.aiColor,
+          score: 0,
+          isAI: false
+        }
+      };
+      base.humanPlayerId = base.playerChoice.playerId;
+    }
+    return base;
+  }
+
+  setup() {
+    const gm = this.scene.gameManager;
+    const aiId = gm.humanPlayerId === 1 ? 2 : 1;
+    const aiOptions = this.scene.getAIOptions(this.options.difficulty || Config.DIFFICULTY.DEFAULT);
+    this.scene.aiPlayer = new AI(aiId, aiOptions);
+  }
+}

--- a/src/modes/index.js
+++ b/src/modes/index.js
@@ -1,0 +1,17 @@
+import { SinglePlayerMode } from './SinglePlayerMode.js';
+import { LocalMultiplayerMode } from './LocalMultiplayerMode.js';
+import { OnlineMultiplayerMode } from './OnlineMultiplayerMode.js';
+
+export function createModeHandler(mode, scene, options) {
+  switch (mode) {
+    case 'single':
+      return new SinglePlayerMode(scene, options);
+    case 'online':
+      return new OnlineMultiplayerMode(scene, options);
+    case 'two':
+    default:
+      return new LocalMultiplayerMode(scene, options);
+  }
+}
+
+export { SinglePlayerMode, LocalMultiplayerMode, OnlineMultiplayerMode };

--- a/src/online/ChatUI.js
+++ b/src/online/ChatUI.js
@@ -1,0 +1,10 @@
+import { Config } from '../config.js';
+
+export class ChatUI {
+  constructor(scene) {
+    const style = Config.textStyle(Config.FONT_SIZES.SMALL, Config.COLORS.TEXT_WHITE);
+    this.text = scene.add.text(10, scene.scale.height - 10, 'Chat connected', style)
+      .setOrigin(0, 1)
+      .setDepth(200);
+  }
+}

--- a/src/online/NetworkClient.js
+++ b/src/online/NetworkClient.js
@@ -1,0 +1,8 @@
+export class NetworkClient {
+  constructor(scene) {
+    this.scene = scene;
+  }
+  connect() {
+    console.log('NetworkClient: connected');
+  }
+}

--- a/tests/gameManager.test.js
+++ b/tests/gameManager.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GameManager } from '../src/GameManager.js';
+
+function createHex({ piece = null, blocked = false } = {}) {
+  return { data: { values: { piece, blocked } } };
+}
+
+function createBoard(hexEntries) {
+  const map = new Map();
+  hexEntries.forEach(([key, piece, blocked]) => {
+    map.set(key, createHex({ piece, blocked }));
+  });
+  return {
+    hexMap: map,
+    forEachHex(cb) { map.forEach(cb); }
+  };
+}
+
+test('boardFull detects all playable hexes occupied', () => {
+  const board = createBoard([
+    ['0,0', {} , false]
+  ]);
+  const ui = {};
+  const scene = { add: { layer: () => ({}) } };
+  const gm = new GameManager(board, ui, scene);
+  assert.equal(gm.boardFull(), true);
+});
+
+test('boardFull detects remaining empty hexes', () => {
+  const board = createBoard([
+    ['0,0', {} , false],
+    ['0,1', null, false]
+  ]);
+  const ui = {};
+  const scene = { add: { layer: () => ({}) } };
+  const gm = new GameManager(board, ui, scene);
+  assert.equal(gm.boardFull(), false);
+});
+
+test('getWinner returns player with higher score', () => {
+  const board = createBoard([]);
+  const ui = {};
+  const scene = { add: { layer: () => ({}) } };
+  const gm = new GameManager(board, ui, scene);
+  gm.players[1].score = 5;
+  gm.players[2].score = 3;
+  assert.equal(gm.getWinner().id, 1);
+});

--- a/tests/modes.test.js
+++ b/tests/modes.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createModeHandler, SinglePlayerMode, LocalMultiplayerMode, OnlineMultiplayerMode } from '../src/modes/index.js';
+import { Config } from '../src/config.js';
+import { AI } from '../src/AI.js';
+import { NetworkClient } from '../src/online/NetworkClient.js';
+import { ChatUI } from '../src/online/ChatUI.js';
+
+// Utility stub for chat UI expectations
+function createStubSceneForChat() {
+  return {
+    add: {
+      text: () => ({
+        setOrigin() { return this; },
+        setDepth() { return this; }
+      })
+    },
+    scale: { height: 600 }
+  };
+}
+
+test('createModeHandler returns correct mode instances', () => {
+  const scene = {};
+  assert.ok(createModeHandler('single', scene) instanceof SinglePlayerMode);
+  assert.ok(createModeHandler('two', scene) instanceof LocalMultiplayerMode);
+  assert.ok(createModeHandler('online', scene) instanceof OnlineMultiplayerMode);
+});
+
+test('SinglePlayerMode.setup creates AI player', () => {
+  const scene = {
+    getAIOptions: () => ({ weights: {} }),
+    gameManager: { humanPlayerId: 1 }
+  };
+  const mode = new SinglePlayerMode(scene, { difficulty: Config.DIFFICULTY.DEFAULT });
+  assert.equal(scene.aiPlayer, undefined);
+  mode.setup();
+  assert.ok(scene.aiPlayer instanceof AI);
+});
+
+test('SinglePlayerMode.getGameManagerOptions sets player options', () => {
+  const choice = { playerId: 2, playerColor: 0x111111, aiColor: 0x222222 };
+  const mode = new SinglePlayerMode({}, { playerChoice: choice });
+  const opts = mode.getGameManagerOptions();
+  assert.equal(opts.humanPlayerId, 2);
+  assert.equal(opts.players[1].color, choice.aiColor);
+  assert.equal(opts.players[2].color, choice.playerColor);
+});
+
+test('OnlineMultiplayerMode.setup initializes network and chat', () => {
+  const scene = createStubSceneForChat();
+  const mode = new OnlineMultiplayerMode(scene, {});
+  mode.setup();
+  assert.ok(mode.network instanceof NetworkClient);
+  assert.ok(mode.chat instanceof ChatUI);
+});


### PR DESCRIPTION
## Summary
- introduce mode handler system for shared GameScene
- add dedicated classes for singleplayer, local, and online modes
- wire up placeholder chat and networking for online multiplayer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689905db89f8832d89f6faf45b726198