### PR TITLE
Add waiting room matchmaking and chat to online mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,123 @@
+{
+  "name": "capitol-conquest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "capitol-conquest",
+      "version": "1.0.0",
+      "dependencies": {
+        "socket.io-client": "^4.7.4"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test"
+  },
+  "dependencies": {
+    "socket.io-client": "^4.7.4"
   }
 }

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,13 @@
+# Capitol Conquest Multiplayer Server
+
+Example Express + Socket.io server providing matchmaking and real-time turn synchronization for the Phaser game.
+
+## Running
+
+```
+cd server
+npm install
+node index.js
+```
+
+The server assigns players into rooms, relays moves and handles simple reconnect logic. Persisting state or advanced validation can be layered on top.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,66 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import { GameRoomManager } from './roomManager.js';
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: { origin: '*' }
+});
+
+const rooms = new GameRoomManager();
+
+io.on('connection', socket => {
+  console.log('client connected', socket.id);
+
+  socket.on('joinMatch', () => {
+    const room = rooms.assignRoom(socket);
+    socket.join(room.id);
+    const playerId = room.getPlayerId(socket.id);
+    socket.emit('joined', { roomId: room.id, playerId });
+
+    if (room.isReady()) {
+      io.to(room.id).emit('matchFound');
+      setTimeout(() => {
+        io.to(room.id).emit('startGame', {
+          roomId: room.id,
+          state: room.state,
+          firstTurn: room.turn
+        });
+      }, 3000);
+    } else {
+      socket.emit('waiting');
+    }
+  });
+
+  socket.on('makeMove', move => {
+    const room = rooms.getRoomBySocket(socket.id);
+    if (!room) return;
+    room.applyMove(move);
+    socket.to(room.id).emit('opponentMove', move);
+  });
+
+  socket.on('chatMessage', message => {
+    const room = rooms.getRoomBySocket(socket.id);
+    if (!room) return;
+    io.to(room.id).emit('chatMessage', {
+      playerId: room.getPlayerId(socket.id),
+      message
+    });
+  });
+
+  socket.on('disconnect', () => {
+    const room = rooms.getRoomBySocket(socket.id);
+    if (!room) return;
+    room.markDisconnected(socket.id);
+    socket.to(room.id).emit('opponentLeft');
+  });
+
+  socket.on('reconnectRoom', ({ roomId, playerId }) => {
+    rooms.reconnect(roomId, playerId, socket);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log(`Server listening on ${PORT}`));

--- a/server/index.js
+++ b/server/index.js
@@ -6,37 +6,59 @@ import { GameRoomManager } from './roomManager.js';
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server, {
-  cors: { origin: '*' }
+  cors: { 
+    origin: '*',
+    methods: ['GET', 'POST']
+  }
 });
 
 const rooms = new GameRoomManager();
 
 io.on('connection', socket => {
-  console.log('client connected', socket.id);
+  console.log('Client connected:', socket.id);
 
   socket.on('joinMatch', () => {
+    console.log('Player requesting to join match:', socket.id);
+    
     const room = rooms.assignRoom(socket);
     socket.join(room.id);
     const playerId = room.getPlayerId(socket.id);
+    
+    console.log(`Player ${socket.id} assigned to room ${room.id} as player ${playerId}`);
+    
+    // Send joined confirmation
     socket.emit('joined', { roomId: room.id, playerId });
 
     if (room.isReady()) {
+      console.log(`Room ${room.id} is ready, starting match`);
+      // Notify both players that match was found
       io.to(room.id).emit('matchFound');
+      
+      // Start game after countdown delay
       setTimeout(() => {
+        const gameState = room.initializeGame();
         io.to(room.id).emit('startGame', {
           roomId: room.id,
-          state: room.state,
+          state: gameState,
           firstTurn: room.turn
         });
-      }, 3000);
+        console.log(`Game started in room ${room.id}`);
+      }, 3500); // 3.5 seconds for countdown + buffer
     } else {
+      // Player is waiting for opponent
       socket.emit('waiting');
+      console.log(`Player ${socket.id} is waiting for opponent in room ${room.id}`);
     }
   });
 
   socket.on('makeMove', move => {
     const room = rooms.getRoomBySocket(socket.id);
-    if (!room) return;
+    if (!room) {
+      console.log('Move from unknown room:', socket.id);
+      return;
+    }
+    
+    console.log(`Move received from ${socket.id} in room ${room.id}:`, move);
     room.applyMove(move);
     socket.to(room.id).emit('opponentMove', move);
   });
@@ -44,23 +66,41 @@ io.on('connection', socket => {
   socket.on('chatMessage', message => {
     const room = rooms.getRoomBySocket(socket.id);
     if (!room) return;
+    
+    const playerId = room.getPlayerId(socket.id);
+    console.log(`Chat message from player ${playerId} in room ${room.id}: ${message}`);
+    
     io.to(room.id).emit('chatMessage', {
-      playerId: room.getPlayerId(socket.id),
+      playerId,
       message
     });
   });
 
   socket.on('disconnect', () => {
+    console.log('Client disconnected:', socket.id);
+    
     const room = rooms.getRoomBySocket(socket.id);
     if (!room) return;
+    
+    console.log(`Player left room ${room.id}`);
     room.markDisconnected(socket.id);
     socket.to(room.id).emit('opponentLeft');
+    
+    // Clean up empty rooms
+    if (room.isEmpty()) {
+      rooms.removeRoom(room.id);
+      console.log(`Removed empty room ${room.id}`);
+    }
   });
 
   socket.on('reconnectRoom', ({ roomId, playerId }) => {
+    console.log(`Reconnection attempt: room ${roomId}, player ${playerId}`);
     rooms.reconnect(roomId, playerId, socket);
   });
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => console.log(`Server listening on ${PORT}`));
+server.listen(PORT, () => {
+  console.log(`Capitol Conquest Server listening on port ${PORT}`);
+  console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -80,9 +80,13 @@ io.on('connection', socket => {
     console.log('Client disconnected:', socket.id);
     
     const room = rooms.getRoomBySocket(socket.id);
-    if (!room) return;
+    if (!room) {
+      console.log('Disconnected client was not in any room');
+      return;
+    }
     
-    console.log(`Player left room ${room.id}`);
+    const playerId = room.getPlayerId(socket.id);
+    console.log(`Player ${playerId} left room ${room.id} - notifying opponent`);
     room.markDisconnected(socket.id);
     socket.to(room.id).emit('opponentLeft');
     
@@ -90,6 +94,8 @@ io.on('connection', socket => {
     if (room.isEmpty()) {
       rooms.removeRoom(room.id);
       console.log(`Removed empty room ${room.id}`);
+    } else {
+      console.log(`Room ${room.id} still has players, keeping it alive`);
     }
   });
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "capitol-conquest-server",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.4"
+  }
+}

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -30,6 +30,9 @@ class GameRoom {
     // Initialize a proper game state with starting pieces
     const s = 5; // Standard board size (matches Config.BOARD.DEFAULT_SIZE)
     
+    // Generate a board seed for consistent board layout across clients
+    const boardSeed = Math.floor(Math.random() * 1000000);
+    
     // Correct corner positions for both players (6 corners of hexagon)
     // Player 1 gets 3 corners, Player 2 gets 3 opposite corners
     const initialPieces = [
@@ -49,7 +52,8 @@ class GameRoom {
       currentPlayer: this.turn,
       gameStarted: true,
       startTime: new Date(),
-      moveHistory: []
+      moveHistory: [],
+      boardSeed: boardSeed  // Add board seed to game state
     };
     
     console.log(`Game initialized in room ${this.id}, player ${this.turn} goes first`);

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -4,11 +4,13 @@ class GameRoom {
     this.players = new Map(); // socket.id -> playerId
     this.state = { pieces: [], currentPlayer: 1 }; // minimal game state
     this.turn = 1;
+    this.createdAt = new Date();
   }
 
   addPlayer(socket) {
     const playerId = this.players.size + 1;
     this.players.set(socket.id, playerId);
+    console.log(`Added player ${playerId} (${socket.id}) to room ${this.id}`);
     return playerId;
   }
 
@@ -16,18 +18,68 @@ class GameRoom {
     return this.players.size === 2;
   }
 
+  isEmpty() {
+    return this.players.size === 0;
+  }
+
   getPlayerId(socketId) {
     return this.players.get(socketId);
   }
 
+  initializeGame() {
+    // Initialize a proper game state with starting pieces
+    const s = 5; // Standard board size (matches Config.BOARD.DEFAULT_SIZE)
+    
+    // Correct corner positions for both players (6 corners of hexagon)
+    // Player 1 gets 3 corners, Player 2 gets 3 opposite corners
+    const initialPieces = [
+      // Player 1 pieces (3 corners)
+      { q: -s, r: 0, player: 1 },     // Left corner
+      { q: 0, r: -s, player: 1 },     // Top-right corner  
+      { q: -s, r: s, player: 1 },     // Bottom-left corner
+      
+      // Player 2 pieces (3 opposite corners)
+      { q: s, r: 0, player: 2 },      // Right corner
+      { q: 0, r: s, player: 2 },      // Bottom-right corner
+      { q: s, r: -s, player: 2 }      // Top-left corner
+    ];
+    
+    this.state = {
+      pieces: initialPieces,
+      currentPlayer: this.turn,
+      gameStarted: true,
+      startTime: new Date(),
+      moveHistory: []
+    };
+    
+    console.log(`Game initialized in room ${this.id}, player ${this.turn} goes first`);
+    console.log(`Initial pieces:`, initialPieces);
+    return this.state;
+  }
+
   applyMove(move) {
-    // Example: push moves into state; real implementation would validate
+    // Store the move and switch turns
     this.state.lastMove = move;
+    this.state.moveHistory = this.state.moveHistory || [];
+    this.state.moveHistory.push({
+      move,
+      player: this.turn,
+      timestamp: new Date()
+    });
+    
+    // Switch turns
     this.turn = this.turn === 1 ? 2 : 1;
+    console.log(`Move applied in room ${this.id}, now player ${this.turn}'s turn`);
   }
 
   markDisconnected(socketId) {
+    const playerId = this.players.get(socketId);
     this.players.delete(socketId);
+    console.log(`Player ${playerId} (${socketId}) disconnected from room ${this.id}`);
+  }
+
+  getPlayerIds() {
+    return Array.from(this.players.values());
   }
 }
 
@@ -38,29 +90,95 @@ export class GameRoomManager {
   }
 
   assignRoom(socket) {
+    // If no waiting room exists, create one
     if (!this.waitingRoom) {
-      const id = Math.random().toString(36).slice(2, 9);
+      const id = this.generateRoomId();
       this.waitingRoom = new GameRoom(id);
       this.rooms.set(id, this.waitingRoom);
+      console.log(`Created new waiting room: ${id}`);
     }
+
     const room = this.waitingRoom;
-    const playerId = room.addPlayer(socket);
-    if (room.isReady()) this.waitingRoom = null;
+    room.addPlayer(socket);
+
+    // If room is now full, clear the waiting room so next players get a new room
+    if (room.isReady()) {
+      this.waitingRoom = null;
+      console.log(`Room ${room.id} is now full and ready to start`);
+    }
+
     return room;
+  }
+
+  generateRoomId() {
+    // Generate a more readable room ID
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let result = '';
+    for (let i = 0; i < 6; i++) {
+      result += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return result;
   }
 
   getRoomBySocket(socketId) {
     for (const room of this.rooms.values()) {
-      if (room.players.has(socketId)) return room;
+      if (room.players.has(socketId)) {
+        return room;
+      }
     }
     return null;
   }
 
+  removeRoom(roomId) {
+    const room = this.rooms.get(roomId);
+    if (room) {
+      // If this was the waiting room, clear it
+      if (this.waitingRoom && this.waitingRoom.id === roomId) {
+        this.waitingRoom = null;
+      }
+      this.rooms.delete(roomId);
+      console.log(`Removed room ${roomId}`);
+    }
+  }
+
   reconnect(roomId, playerId, socket) {
     const room = this.rooms.get(roomId);
-    if (!room) return;
+    if (!room) {
+      socket.emit('reconnectFailed', { reason: 'Room not found' });
+      return;
+    }
+
+    // Add player back to room
     room.players.set(socket.id, playerId);
     socket.join(room.id);
-    socket.emit('rejoined', { state: room.state, turn: room.turn });
+    
+    socket.emit('rejoined', { 
+      state: room.state, 
+      turn: room.turn,
+      playerId: playerId
+    });
+    
+    console.log(`Player ${playerId} reconnected to room ${roomId}`);
+  }
+
+  // Utility methods for monitoring
+  getRoomCount() {
+    return this.rooms.size;
+  }
+
+  getPlayerCount() {
+    let count = 0;
+    for (const room of this.rooms.values()) {
+      count += room.players.size;
+    }
+    return count;
+  }
+
+  getStats() {
+    return {
+      totalRooms: this.getRoomCount(),
+      totalPlayers: this.getPlayerCount(),
+      waitingRoom: this.waitingRoom ? this.waitingRoom.id : null
+    };
   }
 }

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -1,0 +1,66 @@
+class GameRoom {
+  constructor(id) {
+    this.id = id;
+    this.players = new Map(); // socket.id -> playerId
+    this.state = { pieces: [], currentPlayer: 1 }; // minimal game state
+    this.turn = 1;
+  }
+
+  addPlayer(socket) {
+    const playerId = this.players.size + 1;
+    this.players.set(socket.id, playerId);
+    return playerId;
+  }
+
+  isReady() {
+    return this.players.size === 2;
+  }
+
+  getPlayerId(socketId) {
+    return this.players.get(socketId);
+  }
+
+  applyMove(move) {
+    // Example: push moves into state; real implementation would validate
+    this.state.lastMove = move;
+    this.turn = this.turn === 1 ? 2 : 1;
+  }
+
+  markDisconnected(socketId) {
+    this.players.delete(socketId);
+  }
+}
+
+export class GameRoomManager {
+  constructor() {
+    this.rooms = new Map();
+    this.waitingRoom = null;
+  }
+
+  assignRoom(socket) {
+    if (!this.waitingRoom) {
+      const id = Math.random().toString(36).slice(2, 9);
+      this.waitingRoom = new GameRoom(id);
+      this.rooms.set(id, this.waitingRoom);
+    }
+    const room = this.waitingRoom;
+    const playerId = room.addPlayer(socket);
+    if (room.isReady()) this.waitingRoom = null;
+    return room;
+  }
+
+  getRoomBySocket(socketId) {
+    for (const room of this.rooms.values()) {
+      if (room.players.has(socketId)) return room;
+    }
+    return null;
+  }
+
+  reconnect(roomId, playerId, socket) {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    room.players.set(socket.id, playerId);
+    socket.join(room.id);
+    socket.emit('rejoined', { state: room.state, turn: room.turn });
+  }
+}

--- a/src/GameManager.js
+++ b/src/GameManager.js
@@ -260,8 +260,28 @@ export class GameManager {
   }
 
   onPieceDown(piece) {
-  if (this.players[this.currentPlayer].isAI || this.gameEnded) return;
-    if (piece.data.values.player !== this.currentPlayer) return;
+    if (this.players[this.currentPlayer].isAI || this.gameEnded) return;
+    
+    // In online mode, use network player ID for validation
+    if (this.gameMode === 'online') {
+      // Must be this player's turn
+      if (!this.networkPlayerId || this.networkPlayerId !== this.currentPlayer) {
+        console.log(`Not your turn. You are player ${this.networkPlayerId}, current turn: ${this.currentPlayer}`);
+        this.showTurnWarning();
+        return;
+      }
+      
+      // Piece must belong to the network player
+      if (piece.data.values.player !== this.networkPlayerId) {
+        console.log(`Cannot select opponent's piece. Piece belongs to player ${piece.data.values.player}, you are player ${this.networkPlayerId}`);
+        this.showOwnershipWarning();
+        return;
+      }
+    } else {
+      // Local game validation
+      if (piece.data.values.player !== this.currentPlayer) return;
+    }
+    
     if (this.selectedPiece === piece) return; // already selected
     this.clearHighlights();
     this.selectedPiece = piece;
@@ -342,18 +362,33 @@ export class GameManager {
   onHexClicked(hex) {
     if (this.players[this.currentPlayer].isAI || this.gameEnded) return;
     
-    // In online mode, only allow moves if it's this player's turn and they are the current player
-    if (this.gameMode === 'online' && this.networkPlayerId && this.networkPlayerId !== this.currentPlayer) {
-      console.log(`Not your turn in online mode. You are player ${this.networkPlayerId}, current turn: ${this.currentPlayer}`);
-      return;
+    const piece = hex.data.values.piece;
+    
+    // In online mode, enforce strict turn and ownership validation
+    if (this.gameMode === 'online') {
+      // Must be this player's turn
+      if (!this.networkPlayerId || this.networkPlayerId !== this.currentPlayer) {
+        console.log(`Not your turn in online mode. You are player ${this.networkPlayerId}, current turn: ${this.currentPlayer}`);
+        this.showTurnWarning();
+        return;
+      }
+      
+      // If clicking on a piece, it must belong to the current player
+      if (piece && piece.data.values.player !== this.currentPlayer) {
+        console.log(`Cannot select opponent's piece. Piece belongs to player ${piece.data.values.player}, you are player ${this.currentPlayer}`);
+        this.showOwnershipWarning();
+        return;
+      }
     }
     
-    const piece = hex.data.values.piece;
     if (!this.selectedPiece) {
       if (piece && piece.data.values.player === this.currentPlayer) {
         this.selectPiece(piece);
       } else if (piece) {
         console.log(`Cannot select piece belonging to player ${piece.data.values.player}, current player is ${this.currentPlayer}`);
+        if (this.gameMode === 'online') {
+          this.showOwnershipWarning();
+        }
       }
       return;
     }
@@ -530,16 +565,14 @@ export class GameManager {
   endTurn() {
     this.updateScores();
     this.ui.updateScores(this.players[1].score, this.players[2].score);
-  if (this.checkGameOver()) { this._finalizeGame(); return; }
+    if (this.checkGameOver()) { this._finalizeGame(); return; }
     this.currentPlayer = (this.currentPlayer === 1) ? 2 : 1;
     
-    // Show appropriate turn text for online mode
+    // Always show appropriate turn text for online mode
     if (this.gameMode === 'online' && this.networkPlayerId) {
-      const isMyTurn = this.networkPlayerId === this.currentPlayer;
-      const playerName = this.players[this.currentPlayer].name;
-      const turnText = isMyTurn ? `Your Turn (${playerName})` : `Opponent's Turn (${playerName})`;
-      this.ui.updateTurn(turnText);
-      this.ui.flashTurn(turnText);
+      this.updateOnlineTurnDisplay();
+      // Update visual states of pieces for the new turn
+      this.updatePieceVisualStates();
     } else {
       this.ui.updateTurn(this.players[this.currentPlayer].name);
       this.ui.flashTurn(this.players[this.currentPlayer].name);
@@ -551,7 +584,26 @@ export class GameManager {
     }
   }
 
+  updateOnlineTurnDisplay() {
+    if (!this.networkPlayerId) return;
+    
+    const isMyTurn = this.networkPlayerId === this.currentPlayer;
+    const playerName = this.players[this.currentPlayer].name;
+    const turnText = isMyTurn ? `Your Turn (${playerName})` : `Opponent's Turn (${playerName})`;
+    
+    console.log(`Turn update: Player ${this.networkPlayerId}, Current: ${this.currentPlayer}, My turn: ${isMyTurn}`);
+    
+    this.ui.updateTurn(turnText);
+    this.ui.flashTurn(turnText);
+  }
+
   skipTurn() {
+    // Disable skip in online mode completely
+    if (this.gameMode === 'online') {
+      console.log('Skip turn disabled in online mode');
+      return;
+    }
+    
     // Allow only human to skip own turn and only if game hasn't ended
     if (this.players[this.currentPlayer].isAI || this.gameEnded) return;
     this.clearHighlights();
@@ -560,6 +612,12 @@ export class GameManager {
   }
 
   forfeitGame() {
+    // Disable forfeit in online mode (should handle disconnection differently)
+    if (this.gameMode === 'online') {
+      console.log('Forfeit disabled in online mode');
+      return;
+    }
+    
     // Allow only human to forfeit and only if game hasn't ended
     if (this.gameEnded) return;
     
@@ -734,6 +792,14 @@ export class GameManager {
     return { pieces, currentPlayer: this.currentPlayer };
   }
 
+  // Method to regenerate board with seed for multiplayer consistency
+  regenerateBoardWithSeed(seed) {
+    if (this.scene && this.scene.regenerateBoardWithSeed) {
+      this.scene.regenerateBoardWithSeed(seed);
+      console.log('GameManager: Board regenerated with seed:', seed);
+    }
+  }
+
   loadState(state) {
     if (!state) {
       console.log('GameManager: No state to load');
@@ -790,5 +856,146 @@ export class GameManager {
     this.selectedPiece = piece;
     const networkMove = { q: move.toQ, r: move.toR, type: move.type, isNetworkMove: true };
     this.executeMove(networkMove);
+  }
+
+  showTurnWarning() {
+    // Flash the turn indicator to show it's not their turn
+    if (this.ui.turnText) {
+      this.scene.tweens.add({
+        targets: this.ui.turnText,
+        scaleX: 1.1,
+        scaleY: 1.1,
+        tint: 0xff6666,
+        duration: 200,
+        yoyo: true,
+        onComplete: () => {
+          this.ui.turnText.clearTint();
+        }
+      });
+    }
+  }
+
+  showOwnershipWarning() {
+    // Show a visual warning that they can't select opponent pieces
+    const centerX = this.scene.scale.width / 2;
+    const centerY = this.scene.scale.height / 2 + 100;
+    
+    const warningText = this.scene.add.text(centerX, centerY, "Can't select opponent's pieces!", 
+      Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_RED))
+      .setOrigin(0.5)
+      .setDepth(500)
+      .setAlpha(0);
+    
+    this.scene.tweens.add({
+      targets: warningText,
+      alpha: 1,
+      duration: 200,
+      yoyo: true,
+      hold: 1000,
+      onComplete: () => warningText.destroy()
+    });
+  }
+
+  updatePieceVisualStates() {
+    // Update visual states of all pieces based on current turn and game mode
+    if (this.gameMode !== 'online' || !this.networkPlayerId) return;
+    
+    this.board.forEachHex(hex => {
+      const piece = hex.getData('piece');
+      if (piece) {
+        const isMyPiece = piece.data.values.player === this.networkPlayerId;
+        const isMyTurn = this.networkPlayerId === this.currentPlayer;
+        const originalColor = this.players[piece.data.values.player].color;
+        
+        // Set visual state based on ownership and turn
+        if (isMyPiece && isMyTurn) {
+          // My piece, my turn - fully active with original color
+          piece.setAlpha(1.0);
+          this.updatePieceColor(piece, originalColor, 1.0);
+        } else if (isMyPiece && !isMyTurn) {
+          // My piece, not my turn - slightly dimmed but keep original color
+          piece.setAlpha(0.85);
+          this.updatePieceColor(piece, originalColor, 0.8);
+        } else {
+          // Opponent's piece - more dimmed but still show original color
+          piece.setAlpha(0.7);
+          this.updatePieceColor(piece, originalColor, 0.6);
+        }
+      }
+    });
+  }
+
+  // Helper method to update piece color for Graphics objects
+  updatePieceColor(piece, color, brightness = 1.0) {
+    // Clear existing graphics
+    piece.clear();
+    
+    // Get stored geometry data
+    const pts = piece.getData('pts');
+    const radius = piece.getData('radius');
+    if (!pts || !radius) return;
+    
+    // Apply brightness to color
+    const adjustedColor = this.adjustColorBrightness(color, brightness);
+    
+    // Redraw the piece with new color
+    this.redrawPiece(piece, pts, radius, adjustedColor);
+  }
+
+  // Helper to adjust color brightness
+  adjustColorBrightness(color, brightness) {
+    const r = (color >> 16) & 0xFF;
+    const g = (color >> 8) & 0xFF;
+    const b = color & 0xFF;
+    
+    const newR = Math.min(255, Math.floor(r * brightness));
+    const newG = Math.min(255, Math.floor(g * brightness));
+    const newB = Math.min(255, Math.floor(b * brightness));
+    
+    return (newR << 16) | (newG << 8) | newB;
+  }
+
+  // Helper to redraw piece graphics
+  redrawPiece(g, pts, radius, baseColor) {
+    // Shadow layer
+    g.fillStyle(0x000000, 0.25);
+    g.beginPath();
+    g.moveTo(pts[0].x + 3, pts[0].y + 4);
+    for (let i=1;i<6;i++) g.lineTo(pts[i].x + 3, pts[i].y + 4);
+    g.closePath();
+    g.fillPath();
+    
+    // Base
+    g.lineStyle(2, 0x111111, 0.9);
+    g.fillStyle(baseColor, 1);
+    g.beginPath();
+    g.moveTo(pts[0].x, pts[0].y);
+    for (let i=1;i<6;i++) g.lineTo(pts[i].x, pts[i].y);
+    g.closePath(); g.fillPath(); g.strokePath();
+    
+    // Inner gradient approximation (concentric scaled hexes fading)
+    const steps = 4;
+    for (let s=1; s<=steps; s++) {
+      const t = s/steps;
+      const fade = 0.10 * (1-t);
+      const scale = 1 - 0.18*t;
+      g.fillStyle(0xffffff, fade);
+      g.beginPath();
+      pts.forEach((p,i)=> {
+        const x = p.x * scale - 1.5 * (1-t);
+        const y = p.y * scale - 1.0 * (1-t);
+        if (i===0) g.moveTo(x,y); else g.lineTo(x,y);
+      });
+      g.closePath(); g.fillPath();
+    }
+    
+    // Rim light on top-left edges
+    g.lineStyle(1.5, 0xffffff, 0.4);
+    for (let i=0; i<3; i++) {
+      g.beginPath();
+      g.moveTo(pts[i].x, pts[i].y);
+      g.lineTo(pts[i+1].x, pts[i+1].y);
+      g.strokePath();
+    }
   }
 }

--- a/src/GameManager.js
+++ b/src/GameManager.js
@@ -684,4 +684,31 @@ export class GameManager {
     if (this.players[1].score === this.players[2].score) return null;
     return this.players[1].score > this.players[2].score ? this.players[1] : this.players[2];
   }
+  // Networking helpers
+  getState() {
+    const pieces = [];
+    this.board.hexMap.forEach(hex => {
+      const piece = hex.data.values.piece;
+      if (piece) pieces.push({ q: hex.q, r: hex.r, player: piece.data.values.player });
+    });
+    return { pieces, currentPlayer: this.currentPlayer };
+  }
+
+  loadState(state) {
+    if (!state) return;
+    this.board.hexMap.forEach(hex => {
+      const piece = hex.data.values.piece;
+      if (piece) piece.destroy();
+      hex.data.values.piece = null;
+    });
+    state.pieces.forEach(p => this.addPiece(p.q, p.r, p.player));
+    this.currentPlayer = state.currentPlayer;
+    this.updateScores();
+    this.ui.updateTurn(this.players[this.currentPlayer].name);
+  }
+
+  applyNetworkMove(move) {
+    this.selectedPiece = this.board.getHex(move.fromQ, move.fromR)?.data.values.piece || null;
+    this.executeMove({ q: move.toQ, r: move.toR, type: move.type });
+  }
 }

--- a/src/MenuScene.js
+++ b/src/MenuScene.js
@@ -314,8 +314,14 @@ Player with the most pieces on the board wins!
 
 ⌨️ CONTROLS:
 • ESC - Return to menu
-• F - Forfeit game (in-game)
-• S - Skip turn (in-game)
+• F - Forfeit game (local games only)
+• S - Skip turn (local games only)
+• ENTER - Send chat message (online games)
+
+💬 ONLINE MULTIPLAYER:
+• Real-time chat with your opponent
+• Turn-based gameplay with visual indicators
+• Automatic matchmaking with other players
 
 💡 STRATEGY TIPS:
 • Use duplicates to expand territory safely

--- a/src/config.js
+++ b/src/config.js
@@ -63,6 +63,67 @@ export const Config = {
     APPS_SCRIPT_URL: 'https://script.google.com/macros/s/AKfycbxicZTTphEMFckFqG6JPBjgF1KHa8zWRTqEMtq2DwUz9ftqru9UqTWfSBZGMRB_FjGX/exec'
   },
   
+  // Game Board Configuration
+  BOARD: {
+    DEFAULT_SIZE: 5,
+    MOBILE_SIZE: 5,
+    DESKTOP_SIZE: 5,
+    HEX_SIZE: {
+      MOBILE: 28,
+      DESKTOP: 36
+    },
+    BLOCKED_PERCENTAGE: 0.10,
+    BLOCKED_PERCENTAGE_REDUCED: 0.05
+  },
+
+  // Audio Configuration
+  AUDIO: {
+    MUSIC_ENABLED: true,
+    SOUND_ENABLED: true,
+    BACKGROUND_MUSIC: true,
+    VOLUMES: {
+      PIECE_MOVE: 0.5,
+      PIECE_JUMP: 0.5,
+      CONVERT: 0.4,
+      BACKGROUND_MUSIC: 0.1
+    }
+  },
+
+  // UI Configuration
+  UI: {
+    MUSIC_TOGGLE_OFFSET: 20,
+    MUSIC_TOGGLE_SCALE_HOVER: 1.2,
+    MUSIC_TOGGLE_SCALE_NORMAL: 1.0,
+    MUSIC_TOGGLE_DEPTH: 200,
+    RESIZE_ASPECT_RATIO_THRESHOLD: 0.2
+  },
+
+  // AI Configuration
+  AI: {
+    BASE_WEIGHTS: {
+      pieceDiff: 4.0,
+      oppMobility: 2.5,
+      centerControl: 1.2,
+      risk: 1.5,
+      jitter: 0.3
+    },
+    DIFFICULTY_WEIGHTS: {
+      HARD: {
+        pieceDiff: 4.5,
+        oppMobility: 3.0,
+        centerControl: 1.5,
+        risk: 1.2
+      },
+      EXPERT: {
+        pieceDiff: 5.0,
+        oppMobility: 3.5,
+        centerControl: 2.0,
+        risk: 1.0,
+        jitter: 0.1
+      }
+    }
+  },
+
   // Game Difficulty Configuration
   DIFFICULTY: {
     DEFAULT: {

--- a/src/modes/OnlineMultiplayerMode.js
+++ b/src/modes/OnlineMultiplayerMode.js
@@ -94,8 +94,12 @@ export class OnlineMultiplayerMode extends BaseMode {
 
   setupNetworkEvents() {
     this.scene.events.on('net-joined', (data) => {
-      this.statusText.setText('Connected to Server');
-      this.playerStatusText.setText(`You are Player ${data.playerId}`);
+      if (this.statusText) {
+        this.statusText.setText('Connected to Server');
+      }
+      if (this.playerStatusText) {
+        this.playerStatusText.setText(`You are Player ${data.playerId}`);
+      }
       
       // Update the GameManager with the network player ID
       if (this.scene.gameManager) {
@@ -104,13 +108,21 @@ export class OnlineMultiplayerMode extends BaseMode {
     });
 
     this.scene.events.on('net-waiting', () => {
-      this.statusText.setText('Waiting for Opponent');
-      this.playerStatusText.setText('Looking for another player...');
+      if (this.statusText) {
+        this.statusText.setText('Waiting for Opponent');
+      }
+      if (this.playerStatusText) {
+        this.playerStatusText.setText('Looking for another player...');
+      }
     });
 
     this.scene.events.on('net-matchFound', () => {
-      this.statusText.setText('Opponent Found!');
-      this.playerStatusText.setText('Match found! Preparing game...');
+      if (this.statusText) {
+        this.statusText.setText('Opponent Found!');
+      }
+      if (this.playerStatusText) {
+        this.playerStatusText.setText('Match found! Preparing game...');
+      }
       this.stopLoadingAnimation();
       this.startCountdown();
     });
@@ -151,8 +163,12 @@ export class OnlineMultiplayerMode extends BaseMode {
 
   startCountdown() {
     let count = 3;
-    this.statusText.setText(`Game Starting in ${count}...`);
-    this.playerStatusText.setText('Get ready!');
+    if (this.statusText) {
+      this.statusText.setText(`Game Starting in ${count}...`);
+    }
+    if (this.playerStatusText) {
+      this.playerStatusText.setText('Get ready!');
+    }
     
     const countdownTimer = this.scene.time.addEvent({
       delay: 1000,
@@ -160,9 +176,13 @@ export class OnlineMultiplayerMode extends BaseMode {
       callback: () => {
         count--;
         if (count > 0) {
-          this.statusText.setText(`Game Starting in ${count}...`);
+          if (this.statusText) {
+            this.statusText.setText(`Game Starting in ${count}...`);
+          }
         } else {
-          this.statusText.setText('Starting Game!');
+          if (this.statusText) {
+            this.statusText.setText('Starting Game!');
+          }
         }
       }
     });
@@ -254,9 +274,15 @@ export class OnlineMultiplayerMode extends BaseMode {
     const centerX = this.scene.scale.width / 2;
     const centerY = this.scene.scale.height / 2;
     
-    this.statusText.setText('Connection Failed');
-    this.playerStatusText.setText('Unable to connect to server');
-    this.loadingDots.setText('');
+    if (this.statusText) {
+      this.statusText.setText('Connection Failed');
+    }
+    if (this.playerStatusText) {
+      this.playerStatusText.setText('Unable to connect to server');
+    }
+    if (this.loadingDots) {
+      this.loadingDots.setText('');
+    }
     
     // Show retry button
     const retryStyle = Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_WHITE);
@@ -266,8 +292,12 @@ export class OnlineMultiplayerMode extends BaseMode {
       .on('pointerdown', () => {
         retryButton.destroy();
         this.network.connect();
-        this.statusText.setText('Connecting...');
-        this.playerStatusText.setText('');
+        if (this.statusText) {
+          this.statusText.setText('Connecting...');
+        }
+        if (this.playerStatusText) {
+          this.playerStatusText.setText('');
+        }
         this.startLoadingAnimation();
       })
       .on('pointerover', () => retryButton.setTint(0x66ff66))
@@ -293,11 +323,35 @@ export class OnlineMultiplayerMode extends BaseMode {
 
   cleanup() {
     this.stopLoadingAnimation();
+    
+    // Remove all scene event listeners to prevent stale references
+    if (this.scene && this.scene.events) {
+      this.scene.events.off('net-joined');
+      this.scene.events.off('net-waiting');
+      this.scene.events.off('net-matchFound');
+      this.scene.events.off('net-startGame');
+      this.scene.events.off('net-chatMessage');
+      this.scene.events.off('net-opponentLeft');
+      this.scene.events.off('net-connectionError');
+    }
+    
     if (this.network && this.network.socket) {
       this.network.socket.disconnect();
     }
     if (this.chat) {
       this.chat.cleanup();
     }
+    
+    // Clean up UI elements
+    if (this.waitingRoomContainer) {
+      this.waitingRoomContainer.destroy();
+      this.waitingRoomContainer = null;
+    }
+    
+    // Clear references to prevent memory leaks
+    this.statusText = null;
+    this.playerStatusText = null;
+    this.loadingDots = null;
+    this.cancelButton = null;
   }
 }

--- a/src/modes/OnlineMultiplayerMode.js
+++ b/src/modes/OnlineMultiplayerMode.js
@@ -1,12 +1,62 @@
 import { BaseMode } from './BaseMode.js';
 import { NetworkClient } from '../online/NetworkClient.js';
 import { ChatUI } from '../online/ChatUI.js';
+import { Config } from '../config.js';
 
 export class OnlineMultiplayerMode extends BaseMode {
   setup() {
-    // Initialize networking and chat UI
+    const style = Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_WHITE);
+    this.statusText = this.scene.add.text(
+      this.scene.scale.width / 2,
+      this.scene.scale.height / 2,
+      'Connecting...',
+      style
+    ).setOrigin(0.5).setDepth(200);
+
+    // Disable board interaction until game starts
+    this.scene.board.hexMap.forEach(hex => hex.getData('hit')?.disableInteractive?.());
+
     this.network = new NetworkClient(this.scene);
+
+    this.scene.events.on('net-waiting', () => {
+      this.statusText.setText('Waiting for opponent...');
+    });
+
+    this.scene.events.on('net-matchFound', () => {
+      this.statusText.setText('Opponent found!');
+      this.startCountdown();
+    });
+
+    this.scene.events.on('net-startGame', () => {
+      this.statusText.destroy();
+      this.enableBoard();
+    });
+
+    this.chat = new ChatUI(this.scene, msg => this.network.sendChat(msg));
+
+    this.scene.events.on('net-chatMessage', data => {
+      this.chat.addMessage(data);
+    });
+
     this.network.connect();
-    this.chat = new ChatUI(this.scene);
+  }
+
+  startCountdown() {
+    let count = 3;
+    this.statusText.setText(`Game starting in ${count}...`);
+    this.scene.time.addEvent({
+      delay: 1000,
+      repeat: 2,
+      callback: () => {
+        count--;
+        if (count > 0) {
+          this.statusText.setText(`Game starting in ${count}...`);
+        }
+      }
+    });
+  }
+
+  enableBoard() {
+    this.scene.board.hexMap.forEach(hex => hex.getData('hit')?.setInteractive?.());
   }
 }

--- a/src/modes/OnlineMultiplayerMode.js
+++ b/src/modes/OnlineMultiplayerMode.js
@@ -5,58 +5,265 @@ import { Config } from '../config.js';
 
 export class OnlineMultiplayerMode extends BaseMode {
   setup() {
-    const style = Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_WHITE);
-    this.statusText = this.scene.add.text(
-      this.scene.scale.width / 2,
-      this.scene.scale.height / 2,
-      'Connecting...',
-      style
-    ).setOrigin(0.5).setDepth(200);
-
+    this.createWaitingRoomUI();
+    
     // Disable board interaction until game starts
     this.scene.board.hexMap.forEach(hex => hex.getData('hit')?.disableInteractive?.());
 
     this.network = new NetworkClient(this.scene);
+    this.setupNetworkEvents();
+
+    // Initialize chat (will be hidden during waiting room)
+    this.chat = new ChatUI(this.scene, msg => this.network.sendChat(msg));
+    this.chat.hide(); // Hide chat initially
+
+    this.network.connect();
+  }
+
+  // Override to prevent automatic initial piece setup in online mode
+  shouldSetupInitialPieces() {
+    return false;
+  }
+
+  // Get player restrictions for online mode
+  getGameManagerOptions() {
+    return {
+      mode: 'online',
+      networkPlayerId: this.network?.playerId || null,
+      // Defer piece setup to network state
+      skipInitialPieces: true
+    };
+  }
+
+  createWaitingRoomUI() {
+    const centerX = this.scene.scale.width / 2;
+    const centerY = this.scene.scale.height / 2;
+    
+    // Create waiting room container
+    this.waitingRoomContainer = this.scene.add.container(0, 0);
+    this.waitingRoomContainer.setDepth(300);
+    
+    // Background overlay
+    this.overlay = this.scene.add.rectangle(
+      centerX, centerY,
+      this.scene.scale.width, this.scene.scale.height,
+      0x000000, 0.8
+    );
+    this.waitingRoomContainer.add(this.overlay);
+    
+    // Main status text
+    const titleStyle = Config.textStyle(Config.FONT_SIZES.LARGE, Config.COLORS.TEXT_WHITE);
+    this.statusText = this.scene.add.text(centerX, centerY - 100, 'Connecting...', titleStyle)
+      .setOrigin(0.5);
+    this.waitingRoomContainer.add(this.statusText);
+    
+    // Player status area
+    const playerStyle = Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_LIGHT);
+    this.playerStatusText = this.scene.add.text(centerX, centerY - 20, '', playerStyle)
+      .setOrigin(0.5);
+    this.waitingRoomContainer.add(this.playerStatusText);
+    
+    // Loading animation dots
+    this.loadingDots = this.scene.add.text(centerX, centerY + 40, '', 
+      Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_WHITE))
+      .setOrigin(0.5);
+    this.waitingRoomContainer.add(this.loadingDots);
+    
+    // Cancel button
+    const buttonStyle = Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_WHITE);
+    this.cancelButton = this.scene.add.text(centerX, centerY + 120, 'Cancel', buttonStyle)
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', () => this.cancelMatchmaking())
+      .on('pointerover', () => this.cancelButton.setTint(0xff6666))
+      .on('pointerout', () => this.cancelButton.clearTint());
+    this.waitingRoomContainer.add(this.cancelButton);
+    
+    // Start loading animation
+    this.startLoadingAnimation();
+  }
+
+  setupNetworkEvents() {
+    this.scene.events.on('net-joined', (data) => {
+      this.statusText.setText('Connected to Server');
+      this.playerStatusText.setText(`You are Player ${data.playerId}`);
+      
+      // Update the GameManager with the network player ID
+      if (this.scene.gameManager) {
+        this.scene.gameManager.setNetworkPlayerId(data.playerId);
+      }
+    });
 
     this.scene.events.on('net-waiting', () => {
-      this.statusText.setText('Waiting for opponent...');
+      this.statusText.setText('Waiting for Opponent');
+      this.playerStatusText.setText('Looking for another player...');
     });
 
     this.scene.events.on('net-matchFound', () => {
-      this.statusText.setText('Opponent found!');
+      this.statusText.setText('Opponent Found!');
+      this.playerStatusText.setText('Match found! Preparing game...');
+      this.stopLoadingAnimation();
       this.startCountdown();
     });
 
     this.scene.events.on('net-startGame', () => {
-      this.statusText.destroy();
+      this.hideWaitingRoom();
       this.enableBoard();
+      this.showChat();
+      
+      // Update UI with current player info and show which player you are
+      this.scene.gameManager.updateScores();
+      
+      const myPlayerId = this.scene.gameManager.networkPlayerId;
+      const currentPlayer = this.scene.gameManager.currentPlayer;
+      const isMyTurn = myPlayerId === currentPlayer;
+      
+      console.log(`Game started: I am player ${myPlayerId}, current turn: ${currentPlayer}, my turn: ${isMyTurn}`);
+      
+      // Update turn display with player identity
+      const playerName = this.scene.gameManager.players[currentPlayer].name;
+      this.scene.gameManager.ui.updateTurn(
+        isMyTurn ? `Your Turn (${playerName})` : `Opponent's Turn (${playerName})`
+      );
+      
+      this.scene.gameManager.ui.updateScores(
+        this.scene.gameManager.players[1].score, 
+        this.scene.gameManager.players[2].score
+      );
     });
-
-    this.chat = new ChatUI(this.scene, msg => this.network.sendChat(msg));
 
     this.scene.events.on('net-chatMessage', data => {
       this.chat.addMessage(data);
     });
 
-    this.network.connect();
+    this.scene.events.on('net-opponentLeft', () => {
+      this.showOpponentLeftMessage();
+    });
+
+    this.scene.events.on('net-connectionError', () => {
+      this.showConnectionError();
+    });
   }
 
   startCountdown() {
     let count = 3;
-    this.statusText.setText(`Game starting in ${count}...`);
-    this.scene.time.addEvent({
+    this.statusText.setText(`Game Starting in ${count}...`);
+    this.playerStatusText.setText('Get ready!');
+    
+    const countdownTimer = this.scene.time.addEvent({
       delay: 1000,
       repeat: 2,
       callback: () => {
         count--;
         if (count > 0) {
-          this.statusText.setText(`Game starting in ${count}...`);
+          this.statusText.setText(`Game Starting in ${count}...`);
+        } else {
+          this.statusText.setText('Starting Game!');
         }
       }
     });
   }
 
+  startLoadingAnimation() {
+    let dots = 0;
+    this.loadingTimer = this.scene.time.addEvent({
+      delay: 500,
+      loop: true,
+      callback: () => {
+        dots = (dots + 1) % 4;
+        this.loadingDots.setText('.'.repeat(dots));
+      }
+    });
+  }
+
+  stopLoadingAnimation() {
+    if (this.loadingTimer) {
+      this.loadingTimer.destroy();
+      this.loadingDots.setText('');
+    }
+  }
+
+  hideWaitingRoom() {
+    if (this.waitingRoomContainer) {
+      this.waitingRoomContainer.setVisible(false);
+    }
+    this.stopLoadingAnimation();
+  }
+
+  showChat() {
+    if (this.chat) {
+      this.chat.show();
+    }
+  }
+
+  cancelMatchmaking() {
+    // Disconnect from network and return to menu
+    if (this.network && this.network.socket) {
+      this.network.socket.disconnect();
+    }
+    this.scene.scene.start('MenuScene');
+  }
+
+  showOpponentLeftMessage() {
+    // Show message and return to menu after delay
+    const centerX = this.scene.scale.width / 2;
+    const centerY = this.scene.scale.height / 2;
+    
+    const messageStyle = Config.textStyle(Config.FONT_SIZES.LARGE, Config.COLORS.TEXT_WHITE);
+    const messageText = this.scene.add.text(centerX, centerY, 'Opponent Left\nReturning to Menu...', messageStyle)
+      .setOrigin(0.5)
+      .setDepth(400);
+    
+    this.scene.time.delayedCall(3000, () => {
+      this.scene.scene.start('MenuScene');
+    });
+  }
+
+  showConnectionError() {
+    const centerX = this.scene.scale.width / 2;
+    const centerY = this.scene.scale.height / 2;
+    
+    this.statusText.setText('Connection Failed');
+    this.playerStatusText.setText('Unable to connect to server');
+    this.loadingDots.setText('');
+    
+    // Show retry button
+    const retryStyle = Config.textStyle(Config.FONT_SIZES.MEDIUM, Config.COLORS.TEXT_WHITE);
+    const retryButton = this.scene.add.text(centerX, centerY + 80, 'Retry', retryStyle)
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', () => {
+        retryButton.destroy();
+        this.network.connect();
+        this.statusText.setText('Connecting...');
+        this.playerStatusText.setText('');
+        this.startLoadingAnimation();
+      })
+      .on('pointerover', () => retryButton.setTint(0x66ff66))
+      .on('pointerout', () => retryButton.clearTint());
+    
+    this.waitingRoomContainer.add(retryButton);
+  }
+
   enableBoard() {
-    this.scene.board.hexMap.forEach(hex => hex.getData('hit')?.setInteractive?.());
+    // Re-enable all hex interactions
+    this.scene.board.hexMap.forEach(hex => {
+      const hitPoly = hex.getData('hit');
+      if (hitPoly) {
+        hitPoly.setInteractive();
+      }
+    });
+    
+    console.log('Board interaction enabled for online multiplayer');
+  }
+
+  cleanup() {
+    this.stopLoadingAnimation();
+    if (this.network && this.network.socket) {
+      this.network.socket.disconnect();
+    }
+    if (this.chat) {
+      this.chat.cleanup();
+    }
   }
 }

--- a/src/online/ChatUI.js
+++ b/src/online/ChatUI.js
@@ -1,10 +1,37 @@
 import { Config } from '../config.js';
 
 export class ChatUI {
-  constructor(scene) {
+  constructor(scene, sendMessage) {
+    this.scene = scene;
+    this.sendMessage = sendMessage;
     const style = Config.textStyle(Config.FONT_SIZES.SMALL, Config.COLORS.TEXT_WHITE);
-    this.text = scene.add.text(10, scene.scale.height - 10, 'Chat connected', style)
+    this.messages = [];
+    this.text = scene.add.text(10, scene.scale.height - 10, '', style)
       .setOrigin(0, 1)
       .setDepth(200);
+
+    if (typeof document !== 'undefined') {
+      this.input = document.createElement('input');
+      this.input.type = 'text';
+      this.input.placeholder = 'Type message';
+      Object.assign(this.input.style, {
+        position: 'absolute',
+        left: '10px',
+        bottom: '10px',
+        width: '200px'
+      });
+      this.input.addEventListener('keydown', e => {
+        if (e.key === 'Enter' && this.input.value.trim()) {
+          this.sendMessage(this.input.value.trim());
+          this.input.value = '';
+        }
+      });
+      document.body.appendChild(this.input);
+    }
+  }
+
+  addMessage({ playerId, message }) {
+    this.messages.push(`P${playerId}: ${message}`);
+    this.text.setText(this.messages.slice(-5).join('\n'));
   }
 }

--- a/src/online/ChatUI.js
+++ b/src/online/ChatUI.js
@@ -4,34 +4,100 @@ export class ChatUI {
   constructor(scene, sendMessage) {
     this.scene = scene;
     this.sendMessage = sendMessage;
-    const style = Config.textStyle(Config.FONT_SIZES.SMALL, Config.COLORS.TEXT_WHITE);
+    this.isVisible = false;
     this.messages = [];
-    this.text = scene.add.text(10, scene.scale.height - 10, '', style)
-      .setOrigin(0, 1)
-      .setDepth(200);
+    
+    this.createChatUI();
+  }
 
+  createChatUI() {
+    const style = Config.textStyle(Config.FONT_SIZES.SMALL, Config.COLORS.TEXT_WHITE);
+    
+    // Chat messages display
+    this.messagesText = this.scene.add.text(10, this.scene.scale.height - 120, '', style)
+      .setOrigin(0, 1)
+      .setDepth(200)
+      .setVisible(false);
+    
+    // Chat input (HTML element for better UX)
     if (typeof document !== 'undefined') {
-      this.input = document.createElement('input');
-      this.input.type = 'text';
-      this.input.placeholder = 'Type message';
-      Object.assign(this.input.style, {
-        position: 'absolute',
-        left: '10px',
-        bottom: '10px',
-        width: '200px'
-      });
-      this.input.addEventListener('keydown', e => {
-        if (e.key === 'Enter' && this.input.value.trim()) {
-          this.sendMessage(this.input.value.trim());
-          this.input.value = '';
-        }
-      });
-      document.body.appendChild(this.input);
+      this.createHTMLInput();
+    }
+  }
+
+  createHTMLInput() {
+    this.inputContainer = document.createElement('div');
+    Object.assign(this.inputContainer.style, {
+      position: 'absolute',
+      left: '10px',
+      bottom: '10px',
+      display: 'none',
+      zIndex: '1000'
+    });
+
+    this.input = document.createElement('input');
+    this.input.type = 'text';
+    this.input.placeholder = 'Type message and press Enter...';
+    Object.assign(this.input.style, {
+      width: '300px',
+      padding: '5px',
+      fontSize: '14px',
+      backgroundColor: 'rgba(0,0,0,0.8)',
+      color: 'white',
+      border: '1px solid #666',
+      borderRadius: '4px'
+    });
+
+    this.input.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && this.input.value.trim()) {
+        this.sendMessage(this.input.value.trim());
+        this.input.value = '';
+      }
+      // Prevent game controls from triggering while typing
+      e.stopPropagation();
+    });
+
+    this.inputContainer.appendChild(this.input);
+    document.body.appendChild(this.inputContainer);
+  }
+
+  show() {
+    this.isVisible = true;
+    if (this.messagesText) {
+      this.messagesText.setVisible(true);
+    }
+    if (this.inputContainer) {
+      this.inputContainer.style.display = 'block';
+    }
+  }
+
+  hide() {
+    this.isVisible = false;
+    if (this.messagesText) {
+      this.messagesText.setVisible(false);
+    }
+    if (this.inputContainer) {
+      this.inputContainer.style.display = 'none';
     }
   }
 
   addMessage({ playerId, message }) {
-    this.messages.push(`P${playerId}: ${message}`);
-    this.text.setText(this.messages.slice(-5).join('\n'));
+    const playerName = playerId === 1 ? 'Player 1' : 'Player 2';
+    this.messages.push(`${playerName}: ${message}`);
+    
+    // Keep only last 5 messages
+    if (this.messages.length > 5) {
+      this.messages.shift();
+    }
+    
+    if (this.messagesText) {
+      this.messagesText.setText(this.messages.join('\n'));
+    }
+  }
+
+  cleanup() {
+    if (this.inputContainer && this.inputContainer.parentNode) {
+      this.inputContainer.parentNode.removeChild(this.inputContainer);
+    }
   }
 }

--- a/src/online/ChatUI.js
+++ b/src/online/ChatUI.js
@@ -6,15 +6,21 @@ export class ChatUI {
     this.sendMessage = sendMessage;
     this.isVisible = false;
     this.messages = [];
+    this.messageTexts = []; // Array to hold individual colored text objects
     
     this.createChatUI();
   }
 
   createChatUI() {
-    const style = Config.textStyle(Config.FONT_SIZES.SMALL, Config.COLORS.TEXT_WHITE);
+    // Use a more visible color for chat - bright cyan/blue for base text
+    const style = Config.textStyle(Config.FONT_SIZES.SMALL, '#000000');
     
-    // Chat messages display
-    this.messagesText = this.scene.add.text(10, this.scene.scale.height - 120, '', style)
+    // Chat messages display - we'll use rich text to support different colors
+    this.messagesText = this.scene.add.text(10, this.scene.scale.height - 120, '', {
+      ...style,
+      wordWrap: { width: 400 },
+      lineSpacing: 4
+    })
       .setOrigin(0, 1)
       .setDepth(200)
       .setVisible(false);
@@ -40,17 +46,20 @@ export class ChatUI {
     this.input.placeholder = 'Type message and press Enter...';
     Object.assign(this.input.style, {
       width: '300px',
-      padding: '5px',
+      padding: '8px',
       fontSize: '14px',
-      backgroundColor: 'rgba(0,0,0,0.8)',
-      color: 'white',
-      border: '1px solid #666',
-      borderRadius: '4px'
+      backgroundColor: 'rgba(0,0,0,0.9)',
+      color: '#00FFFF',
+      border: '2px solid #0088CC',
+      borderRadius: '6px',
+      outline: 'none'
     });
 
     this.input.addEventListener('keydown', e => {
       if (e.key === 'Enter' && this.input.value.trim()) {
-        this.sendMessage(this.input.value.trim());
+        const message = this.input.value.trim();
+        console.log('Sending chat message:', message);
+        this.sendMessage(message);
         this.input.value = '';
       }
       // Prevent game controls from triggering while typing
@@ -64,7 +73,11 @@ export class ChatUI {
   show() {
     this.isVisible = true;
     if (this.messagesText) {
-      this.messagesText.setVisible(true);
+      this.messagesText.setVisible(false); // Keep old text hidden
+    }
+    // Show all individual message texts
+    if (this.messageTexts) {
+      this.messageTexts.forEach(text => text.setVisible(true));
     }
     if (this.inputContainer) {
       this.inputContainer.style.display = 'block';
@@ -76,28 +89,88 @@ export class ChatUI {
     if (this.messagesText) {
       this.messagesText.setVisible(false);
     }
+    // Hide all individual message texts
+    if (this.messageTexts) {
+      this.messageTexts.forEach(text => text.setVisible(false));
+    }
     if (this.inputContainer) {
       this.inputContainer.style.display = 'none';
     }
   }
 
   addMessage({ playerId, message }) {
-    const playerName = playerId === 1 ? 'Player 1' : 'Player 2';
-    this.messages.push(`${playerName}: ${message}`);
+    const playerName = playerId === 1 ? 'Republicans' : 'Democrats';
+    const timestamp = new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
+    
+    // Get party colors - Republicans (red) and Democrats (blue)
+    const playerColor = playerId === 1 ? '#dc2626' : '#2563eb'; // Red for Republicans, Blue for Democrats
+    
+    // Create a formatted message with colored text
+    const formattedMessage = `[${timestamp}] ${playerName}: ${message}`;
+    this.messages.push({ text: formattedMessage, color: playerColor, playerId });
     
     // Keep only last 5 messages
     if (this.messages.length > 5) {
       this.messages.shift();
     }
     
-    if (this.messagesText) {
-      this.messagesText.setText(this.messages.join('\n'));
+    // Update the display with colored messages
+    this.updateMessageDisplay();
+    
+    console.log('Chat message added:', {playerId, message});
+  }
+
+  updateMessageDisplay() {
+    if (!this.messagesText) return;
+    
+    // Create a single text string with color markup for rich text
+    // Since Phaser text doesn't easily support inline colors, we'll destroy and recreate
+    if (this.messageTexts) {
+      this.messageTexts.forEach(text => text.destroy());
     }
+    this.messageTexts = [];
+    
+    // Hide the old text object
+    this.messagesText.setVisible(false);
+    
+    // Create individual text objects for each message with their respective colors
+    const startY = this.scene.scale.height - 120;
+    const lineHeight = 25;
+    
+    this.messages.forEach((msg, index) => {
+      const y = startY - (this.messages.length - 1 - index) * lineHeight;
+      
+      const messageText = this.scene.add.text(10, y, msg.text, {
+        fontSize: Config.FONT_SIZES.SMALL,
+        color: msg.color,
+        fontFamily: 'Arial, sans-serif',
+        wordWrap: { width: 400 },
+        backgroundColor: 'rgba(0,0,0,0.7)',
+        padding: { x: 4, y: 2 }
+      })
+        .setOrigin(0, 0)
+        .setDepth(200)
+        .setVisible(this.isVisible);
+        
+      this.messageTexts.push(messageText);
+    });
   }
 
   cleanup() {
     if (this.inputContainer && this.inputContainer.parentNode) {
       this.inputContainer.parentNode.removeChild(this.inputContainer);
+    }
+    
+    // Clean up individual message texts
+    if (this.messageTexts) {
+      this.messageTexts.forEach(text => text.destroy());
+      this.messageTexts = [];
+    }
+    
+    // Clean up main message text
+    if (this.messagesText) {
+      this.messagesText.destroy();
+      this.messagesText = null;
     }
   }
 }

--- a/src/online/NetworkClient.js
+++ b/src/online/NetworkClient.js
@@ -14,13 +14,23 @@ export class NetworkClient {
       return;
     }
 
+    // If already connected, disconnect first to ensure clean state
+    if (this.socket && this.socket.connected) {
+      console.log('NetworkClient: Disconnecting existing connection before reconnecting');
+      this.disconnect();
+    }
+
     // Load Socket.IO from CDN if not already loaded
     if (typeof io === 'undefined') {
       await this.loadSocketIO();
     }
 
     const target = this.url || this.getServerUrl();
-    this.socket = io(target);
+    console.log('NetworkClient: Connecting to', target);
+    this.socket = io(target, {
+      forceNew: true, // Force a new connection
+      timeout: 10000  // 10 second timeout
+    });
 
     this.socket.on('connect', () => {
       console.log('NetworkClient: connected');

--- a/src/online/NetworkClient.js
+++ b/src/online/NetworkClient.js
@@ -1,8 +1,74 @@
+import { io } from 'socket.io-client';
+
 export class NetworkClient {
-  constructor(scene) {
+  constructor(scene, url) {
     this.scene = scene;
+    this.url = url;
+    this.socket = null;
+    this.playerId = null;
+    this.roomId = null;
   }
+
   connect() {
-    console.log('NetworkClient: connected');
+    if (typeof window === 'undefined') {
+      // In tests or non-browser environments, skip real connection
+      console.log('NetworkClient: running in headless mode, connection skipped');
+      return;
+    }
+    const target = this.url || window.location.origin;
+    this.socket = io(target);
+
+    this.socket.on('connect', () => {
+      console.log('NetworkClient: connected');
+      this.socket.emit('joinMatch');
+    });
+
+    this.socket.on('joined', ({ roomId, playerId }) => {
+      this.playerId = playerId;
+      this.roomId = roomId;
+    });
+
+    this.socket.on('waiting', () => {
+      this.scene.events.emit('net-waiting');
+    });
+
+    this.socket.on('matchFound', () => {
+      this.scene.events.emit('net-matchFound');
+    });
+
+    this.socket.on('startGame', ({ state, firstTurn }) => {
+      // Scene should provide method to load state
+      this.scene.gameManager?.loadState?.(state);
+      this.scene.gameManager.currentPlayer = firstTurn;
+      this.scene.events.emit('net-startGame');
+    });
+
+    this.socket.on('opponentMove', move => {
+      this.scene.gameManager?.applyNetworkMove?.(move);
+    });
+
+    this.socket.on('chatMessage', data => {
+      this.scene.events.emit('net-chatMessage', data);
+    });
+
+    this.socket.on('opponentLeft', () => {
+      console.log('Opponent disconnected');
+    });
+
+    this.socket.on('disconnect', () => {
+      console.log('NetworkClient: disconnected');
+    });
+  }
+
+  sendMove(move) {
+    if (this.socket) {
+      this.socket.emit('makeMove', move);
+    }
+  }
+
+  sendChat(message) {
+    if (this.socket) {
+      this.socket.emit('chatMessage', message);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement server-side matchmaking with waiting status, countdown, and room-wide chat broadcast
- add NetworkClient events and ChatUI for messaging and waiting-room updates
- gate game input until countdown completes and verify chat only loads in online mode

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990c3ed2f8832d96fff3be1b310da2